### PR TITLE
Add Official Pi Network SDK & API Integration (Auth + Payments)

### DIFF
--- a/lib/lib/index.html
+++ b/lib/lib/index.html
@@ -1,0 +1,22 @@
+<script src="https://sdk.minepi.com/pi-sdk.js"></script>
+<script>
+Pi.init({ version: "2.0", sandbox: false });
+
+async function loginWithPi() {
+  const auth = await Pi.authenticate(["username", "payments"]);
+  console.log("Pi User:", auth.user);
+}
+
+async function pay() {
+  const payment = await Pi.createPayment({
+    amount: 1,
+    memo: "Buy NFT",
+    metadata: { itemId: "nft_001" },
+  });
+
+  await fetch("/api/pi/payment", {
+    method: "POST",
+    body: JSON.stringify({ paymentId: payment.identifier }),
+  });
+}
+</script>

--- a/lib/lib/pi.service.js
+++ b/lib/lib/pi.service.js
@@ -1,0 +1,14 @@
+import axios from "axios";
+import { piConfig } from "./pi.config.js";
+
+export async function verifyPiPayment(paymentId) {
+  const res = await axios.get(
+    `${piConfig.baseUrl}/v2/payments/${paymentId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${piConfig.accessToken}`,
+      },
+    }
+  );
+  return res.data;
+}

--- a/lib/pi.config.js
+++ b/lib/pi.config.js
@@ -1,0 +1,5 @@
+export const piConfig = {
+  appId: process.env.PI_APP_ID,
+  accessToken: process.env.PI_ACCESS_TOKEN, // Server API Key dari Pi Dev Portal
+  baseUrl: "https://api.minepi.com",
+};


### PR DESCRIPTION
This pull request adds the first real integration with the **official Pi Network SDK and Platform API** into PiMetaConnect.

### ✨ What’s included
- Added `pi.config.js` for secure Pi App configuration using environment variables.
- Added `pi.service.js` to verify Pi payments via the official Pi Platform API (`/v2/payments/{paymentId}`).
- Added `index.html` frontend example using the **Pi Browser SDK** for:
  - User authentication
  - Creating Pi payments (User → App)

### 🔐 Security & Compliance
- Uses Server API Key from the Pi Developer Portal.
- No fake SDKs or unofficial APIs.
- Follows Pi Network’s recommended payment flow.

### 🎯 Purpose
This sets the foundation for:
- Pi Pay in DEX / NFT / GameFi / DAO modules
- Real Pi-based transactions in PiMetaConnect

Let me know if you’d like me to extend this into:
- DAO treasury payments
- NFT mint + pay flow
- GameFi in-app purchases 🚀